### PR TITLE
Fix eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
     "extends": "hapi",
     "parserOptions": {
         "sourceType": "module"
+    },
+    "env": {
+         "jest": true
     }
 }


### PR DESCRIPTION
### Explanation of change

Previously, when running eslint (part of `npm test`) we would get errors about `jest` not being defined:

```
    5:1   error  'jest' is not defined        no-undef
    8:17  error  'jest' is not defined        no-undef
   11:26  error  'jest' is not defined        no-undef
   14:27  error  'jest' is not defined        no-undef
   15:25  error  'jest' is not defined        no-undef
   34:1   error  'describe' is not defined    no-undef
   36:5   error  'it' is not defined          no-undef
   40:9   error  'expect' is not defined      no-undef
   49:1   error  'describe' is not defined    no-undef
   51:5   error  'beforeEach' is not defined  no-undef
   56:5   error  'it' is not defined          no-undef
   68:13  error  'expect' is not defined      no-undef
   69:13  error  'expect' is not defined      no-undef
   70:13  error  'expect' is not defined      no-undef
   71:13  error  'expect' is not defined      no-undef
   76:5   error  'it' is not defined          no-undef
   92:13  error  'expect' is not defined      no-undef
   93:13  error  'expect' is not defined      no-undef
   98:5   error  'it' is not defined          no-undef
  122:13  error  'expect' is not defined      no-undef
  126:17  error  'expect' is not defined      no-undef
  127:17  error  'expect' is not defined      no-undef
  127:98  error  'expect' is not defined      no-undef
  129:29  error  'expect' is not defined      no-undef
  130:37  error  'expect' is not defined      no-undef
  131:36  error  'expect' is not defined      no-undef
  135:34  error  'expect' is not defined      no-undef
  136:34  error  'expect' is not defined      no-undef
  141:30  error  'expect' is not defined      no-undef
  150:5   error  'it' is not defined          no-undef
  165:13  error  'expect' is not defined      no-undef
  169:17  error  'expect' is not defined      no-undef
  170:17  error  'expect' is not defined      no-undef
  170:80  error  'expect' is not defined      no-undef
  172:29  error  'expect' is not defined      no-undef
  173:37  error  'expect' is not defined      no-undef
  174:36  error  'expect' is not defined      no-undef
  178:34  error  'expect' is not defined      no-undef
  179:34  error  'expect' is not defined      no-undef
  184:30  error  'expect' is not defined      no-undef

✖ 40 problems (40 errors, 0 warnings)
```

Adding `jest` to the `.eslintrc` file makes the tests and linting pass.

```
> hapi-raven-boom@6.1.0 test /hapi-raven-boom
> npm run eslint && jest --runInBand


> hapi-raven-boom@6.1.0 eslint /hapi-raven-boom
> eslint .

 PASS  __tests__/index.js
  registration assertions
    ✓ should throw error when dsn is missing (11ms)
  plugin functionality
    ✓ should expose access to the raven client (11ms)
    ✓ should ensure the raven client is setup with the supplied settings (6ms)
    ✓ should send an exception to sentry (24ms)
    ✓ should send a message to sentry (8ms)

----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |      100 |      100 |      100 |      100 |                |
 index.js |      100 |      100 |      100 |      100 |                |
----------|----------|----------|----------|----------|----------------|
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        1.134s
Ran all test suites.
```

### Testing steps

1. Check out this branch locally
2. Run `npm test` from the command line
3. Observe that linting succeeds and tests pass